### PR TITLE
Store a metadata_version in harvested metadata

### DIFF
--- a/libcflib/harvester.py
+++ b/libcflib/harvester.py
@@ -2,15 +2,16 @@
 Harvests metadata out of a built conda package
 """
 
-import tarfile
-import os
-import json
-from ruamel_yaml.scanner import ScannerError
-
 import io
+import json
+import os
 import sys
+import tarfile
 
+from ruamel_yaml.scanner import ScannerError
 import ruamel_yaml
+
+METADATA_VERSION = 1
 
 
 def filter_file(filename):
@@ -59,6 +60,7 @@ def harvest(io_like):
     index = json.load(tf.extractfile("info/index.json"))
 
     return {
+        "metadata_version": METADATA_VERSION,
         "name": index["name"],
         "version": index["version"],
         "index": index,

--- a/libcflib/schemas.py
+++ b/libcflib/schemas.py
@@ -118,7 +118,7 @@ SCHEMAS = {
                 "type": "dict",
             },
             "name": {"schema": {"type": "string"}, "type": "list"},
-            "metdata_version": {"schema": {"type": "integer"}, "type": "integer"},
+            "metadata_version": {"type": "integer"},
             "raw_recipe": {"schema": {"type": "string"}, "type": "list"},
             "rendered_recipe": {
                 "schema": {

--- a/libcflib/schemas.py
+++ b/libcflib/schemas.py
@@ -118,6 +118,7 @@ SCHEMAS = {
                 "type": "dict",
             },
             "name": {"schema": {"type": "string"}, "type": "list"},
+            "metdata_version": {"schema": {"type": "integer"}, "type": "integer"},
             "raw_recipe": {"schema": {"type": "string"}, "type": "list"},
             "rendered_recipe": {
                 "schema": {


### PR DESCRIPTION
This allows us to at some point in the future more easily change the behavior
of metadata_version.