### PR TITLE
Force Python 3.9.* in run environment so xonsh==0.9.24 can be used

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,8 +11,10 @@ jobs:
       - uses: actions/checkout@v2
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: 3.7
-          channels: conda-forge,defaults
+          miniforge-variant: Mambaforge
+          use-mamba: true
+          python-version: 3.9
+          channels: conda-forge
           channel-priority: strict
           show-channel-urls: true
 
@@ -20,7 +22,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda config --set always_yes True
-          conda install --file requirements/run.txt --file requirements/tests.txt pip
+          mamba install --file requirements/run.txt --file requirements/tests.txt pip
           pip install --no-deps -e .
 
       - name: lint

--- a/requirements/run.txt
+++ b/requirements/run.txt
@@ -1,4 +1,5 @@
 python==3.9.*
+pip
 cerberus
 tornado
 xonsh==0.9.24

--- a/requirements/run.txt
+++ b/requirements/run.txt
@@ -1,3 +1,4 @@
+python==3.9.*
 cerberus
 tornado
 xonsh==0.9.24

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,3 +1,2 @@
 pytest
 flake8
-pytest-tornado

--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,3 +1,3 @@
-pytest <4
+pytest
 flake8
 pytest-tornado


### PR DESCRIPTION
Part of the workaround for https://github.com/regro/libcfgraph/issues/12